### PR TITLE
Use env vars for model and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ pip install -r requirements.txt
 ./start.sh
 ```
 
+Puedes personalizar la ruta del modelo y el puerto exportando las
+variables de entorno `MODEL_PATH` y `PORT` antes de arrancar:
+
+```bash
+export MODEL_PATH=/ruta/al/modelo.gguf
+export PORT=9000
+./start.sh
+```
+
 ## 🧪 Cómo probar
 
 Desde consola del navegador:
@@ -26,3 +35,10 @@ fetch("http://localhost:8000/api/chat", {
 ```
 
 Modelo usado: `mistral-7b-instruct-v0.1.Q4_K_M.gguf`
+
+## Abrir la interfaz
+
+Con el servidor en marcha abre `fennec_assistant.html` en tu navegador.
+Por defecto busca la API en `http://localhost:8000`, por lo que si cambiaste
+el puerto asegúrate de modificar la URL en el código o ajustar la variable
+`PORT` antes de abrir el archivo.

--- a/server.py
+++ b/server.py
@@ -2,8 +2,10 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from llama_cpp import Llama
+import os
 
-MODEL_PATH = "./mistral-7b-instruct-v0.1.Q4_K_M.gguf"
+MODEL_PATH = os.getenv("MODEL_PATH", "./mistral-7b-instruct-v0.1.Q4_K_M.gguf")
+PORT = int(os.getenv("PORT", "8000"))
 
 app = FastAPI()
 app.add_middleware(

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 source venv/bin/activate
-uvicorn vector_rag_fennec:app --reload --port 8000
+uvicorn vector_rag_fennec:app --reload --port ${PORT:-8000}

--- a/vector_rag_fennec.py
+++ b/vector_rag_fennec.py
@@ -2,6 +2,7 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from llama_cpp import Llama
+import os
 from langchain.embeddings import HuggingFaceEmbeddings
 from langchain.vectorstores import Chroma
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -14,8 +15,11 @@ vectordb = Chroma.from_documents(chunks, embedding=HuggingFaceEmbeddings(model_n
 app = FastAPI()
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
 
+MODEL_PATH = os.getenv("MODEL_PATH", "./mistral-7b-instruct-v0.1.Q4_K_M.gguf")
+PORT = int(os.getenv("PORT", "8000"))
+
 llm = Llama(
-    model_path="./mistral-7b-instruct-v0.1.Q4_K_M.gguf",
+    model_path=MODEL_PATH,
     n_ctx=2048, n_threads=8, n_gpu_layers=35,
     chat_format="mistral-instruct"
 )


### PR DESCRIPTION
## Summary
- read `MODEL_PATH` and `PORT` from environment in both server modules
- allow overriding port in `start.sh`
- document environment variables and how to open the assistant UI

## Testing
- `python3 -m py_compile server.py vector_rag_fennec.py`
- `bash -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68505dc2feec8326bbf32724c664e943