### PR TITLE
Improve chat interface layout

### DIFF
--- a/fennec_assistant.html
+++ b/fennec_assistant.html
@@ -16,16 +16,16 @@
         h1 {
             color: #ffcc00;
         }
-        #chatbox {
+        #chatlog {
+            list-style: none;
+            padding: 1rem;
             width: 80%;
             max-width: 800px;
             background-color: #2a2a2a;
-            padding: 1rem;
             border-radius: 10px;
             margin-bottom: 1rem;
             height: 400px;
             overflow-y: auto;
-            white-space: pre-wrap;
         }
         #inputArea {
             width: 80%;
@@ -51,33 +51,61 @@
             color: #1e1e1e;
             cursor: pointer;
         }
-        .user, .fennec {
+        li {
             margin: 0.5rem 0;
+            display: flex;
+        }
+        .bubble {
+            padding: 0.5rem 1rem;
+            border-radius: 10px;
+            max-width: 70%;
+            white-space: pre-wrap;
         }
         .user {
-            color: #00ffff;
+            justify-content: flex-end;
+        }
+        .user .bubble {
+            background-color: #00ffff;
+            color: #1e1e1e;
         }
         .fennec {
-            color: #ffa07a;
+            justify-content: flex-start;
+        }
+        .fennec .bubble {
+            background-color: #ffa07a;
+            color: #1e1e1e;
         }
     </style>
 </head>
 <body>
     <h1>🦊 FENNEC Assistant</h1>
-    <div id="chatbox"></div>
+    <ul id="chatlog"></ul>
     <div id="inputArea">
         <textarea id="userInput" placeholder="Ask FENNEC anything..."></textarea>
         <button onclick="sendMessage()">Send</button>
     </div>
 
     <script>
+        const chatlog = document.getElementById("chatlog");
+
+        function appendMessage(role, text) {
+            const li = document.createElement("li");
+            li.className = role;
+            const bubble = document.createElement("div");
+            bubble.className = "bubble";
+            const time = new Date().toLocaleTimeString();
+            bubble.textContent = `${text} (${time})`;
+            li.appendChild(bubble);
+            chatlog.appendChild(li);
+            chatlog.scrollTop = chatlog.scrollHeight;
+        }
+
         async function sendMessage() {
             const input = document.getElementById("userInput");
-            const chatbox = document.getElementById("chatbox");
             const message = input.value.trim();
             if (!message) return;
 
-            chatbox.innerHTML += "\n<span class='user'>You: " + message + "</span>";
+            appendMessage('user', message);
 
             const res = await fetch("http://localhost:8000/api/chat", {
                 method: "POST",
@@ -86,8 +114,7 @@
             });
 
             const data = await res.json();
-            chatbox.innerHTML += "\n<span class='fennec'>FENNEC: " + data.response + "</span>";
-            chatbox.scrollTop = chatbox.scrollHeight;
+            appendMessage('fennec', data.response);
             input.value = "";
         }
     </script>


### PR DESCRIPTION
## Summary
- refactor HTML UI to store messages in a `<ul>` list
- style list items as speech bubbles with timestamps
- update JavaScript to append messages to the new list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850602b4dc88326be51f9d86d4efeac