### PR TITLE
Add configurable API URL in interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ docker run -p 8000:8000 fennec-back
 ## Abrir la interfaz
 
 Con el servidor en marcha abre `fennec_assistant.html` en tu navegador.
-Por defecto busca la API en `http://localhost:8000`, por lo que si cambiaste
-el puerto asegúrate de modificar la URL en el código o ajustar la variable
-`PORT` antes de abrir el archivo.
+La página ahora incluye un campo donde puedes indicar la URL base de la API.
+Se inicializa con `http://localhost:8000`, pero puedes cambiarlo en tiempo de ejecución
+o dejarlo vacío para que use el origen de la página (`window.location.origin`).

--- a/fennec_assistant.html
+++ b/fennec_assistant.html
@@ -33,6 +33,9 @@
             display: flex;
             gap: 1rem;
         }
+        #configArea {
+            margin: 1rem 0;
+        }
         textarea {
             flex-grow: 1;
             padding: 1rem;
@@ -64,6 +67,9 @@
 </head>
 <body>
     <h1>🦊 FENNEC Assistant</h1>
+    <div id="configArea">
+        <input type="text" id="baseUrl" value="http://localhost:8000" placeholder="API base URL" />
+    </div>
     <div id="chatbox"></div>
     <div id="inputArea">
         <textarea id="userInput" placeholder="Ask FENNEC anything..."></textarea>
@@ -79,7 +85,8 @@
 
             chatbox.innerHTML += "\n<span class='user'>You: " + message + "</span>";
 
-            const res = await fetch("http://localhost:8000/api/chat", {
+            const base = (document.getElementById("baseUrl")?.value.trim()) || window.location.origin;
+            const res = await fetch(base + "/api/chat", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ prompt: message })


### PR DESCRIPTION
## Summary
- allow setting API base URL in the HTML interface
- use that value (or the page origin) for fetch requests
- document configuration field in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506028bed48326af8d01785868f20c