### PR TITLE
Add RULES_FILE env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# default rules file location
+ENV RULES_FILE=Bizee_rules.txt
+
 COPY requirements.txt .
 RUN python -m venv venv \
     && . venv/bin/activate \

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ pip install -r requirements.txt
 ./start.sh
 ```
 
-Puedes personalizar la ruta del modelo y el puerto exportando las
-variables de entorno `MODEL_PATH` y `PORT` antes de arrancar:
+Puedes personalizar la ruta del modelo, el puerto y el archivo de reglas exportando las
+variables de entorno `MODEL_PATH`, `PORT` y `RULES_FILE` antes de arrancar:
 
 ```bash
 export MODEL_PATH=/ruta/al/modelo.gguf
 export PORT=9000
+export RULES_FILE=/ruta/a/mis_reglas.txt
 ./start.sh
 ```
 

--- a/vector_rag_fennec.py
+++ b/vector_rag_fennec.py
@@ -8,7 +8,9 @@ from langchain.vectorstores import Chroma
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.document_loaders import TextLoader
 
-docs = TextLoader("Bizee_rules.txt").load()
+# determine rules path from environment
+RULES_FILE = os.getenv("RULES_FILE", "Bizee_rules.txt")
+docs = TextLoader(RULES_FILE).load()
 chunks = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200).split_documents(docs)
 vectordb = Chroma.from_documents(chunks, embedding=HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2"))
 


### PR DESCRIPTION
## Summary
- make path to Bizee_rules.txt configurable via RULES_FILE env var
- update Dockerfile to set default RULES_FILE
- document RULES_FILE in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68506e0295588326a3d630861464cca3