### PR TITLE
Add httpx and patch tests for missing deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ uvicorn
 langchain
 chromadb
 sentence-transformers
+httpx
+pytest

--- a/tests/test_chat_endpoint.py
+++ b/tests/test_chat_endpoint.py
@@ -21,6 +21,56 @@ def client(monkeypatch):
     dummy_module.Llama = DummyLlama
     monkeypatch.setitem(sys.modules, "llama_cpp", dummy_module)
 
+    # Provide lightweight stand-ins for langchain components to avoid heavy
+    # dependencies when importing the application module.
+    langchain_pkg = types.ModuleType("langchain")
+    embeddings_pkg = types.ModuleType("langchain.embeddings")
+    vectorstores_pkg = types.ModuleType("langchain.vectorstores")
+    splitter_pkg = types.ModuleType("langchain.text_splitter")
+    loaders_pkg = types.ModuleType("langchain.document_loaders")
+
+    class DummyEmbeddings:
+        def __init__(self, *a, **k):
+            pass
+
+    class DummyChroma:
+        @classmethod
+        def from_documents(cls, docs, embedding):
+            return cls()
+
+        def similarity_search(self, *a, **k):
+            return []
+
+    class DummySplitter:
+        def __init__(self, *a, **k):
+            pass
+
+        def split_documents(self, docs):
+            return docs
+
+    class DummyLoader:
+        def __init__(self, *a, **k):
+            pass
+
+        def load(self):
+            return [types.SimpleNamespace(page_content="dummy")]
+
+    embeddings_pkg.HuggingFaceEmbeddings = DummyEmbeddings
+    vectorstores_pkg.Chroma = DummyChroma
+    splitter_pkg.RecursiveCharacterTextSplitter = DummySplitter
+    loaders_pkg.TextLoader = DummyLoader
+
+    langchain_pkg.embeddings = embeddings_pkg
+    langchain_pkg.vectorstores = vectorstores_pkg
+    langchain_pkg.text_splitter = splitter_pkg
+    langchain_pkg.document_loaders = loaders_pkg
+
+    monkeypatch.setitem(sys.modules, "langchain", langchain_pkg)
+    monkeypatch.setitem(sys.modules, "langchain.embeddings", embeddings_pkg)
+    monkeypatch.setitem(sys.modules, "langchain.vectorstores", vectorstores_pkg)
+    monkeypatch.setitem(sys.modules, "langchain.text_splitter", splitter_pkg)
+    monkeypatch.setitem(sys.modules, "langchain.document_loaders", loaders_pkg)
+
     root_dir = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, root_dir)
 


### PR DESCRIPTION
## Summary
- include httpx and pytest in `requirements.txt`
- mock langchain modules in the test fixture so heavy packages aren't needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685195e86f6483268b5468bdf3e31531