### PR TITLE
Configure CORS via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ pip install -r requirements.txt
 ./start.sh
 ```
 
-Puedes personalizar la ruta del modelo, el puerto y el archivo de reglas exportando las
-variables de entorno `MODEL_PATH`, `PORT` y `RULES_FILE` antes de arrancar:
+Puedes personalizar la ruta del modelo, el puerto, los orígenes permitidos y el archivo de reglas exportando las
+variables de entorno `MODEL_PATH`, `PORT`, `ALLOWED_ORIGINS` y `RULES_FILE` antes de arrancar:
 
 ```bash
 export MODEL_PATH=/ruta/al/modelo.gguf
 export PORT=9000
 export RULES_FILE=/ruta/a/mis_reglas.txt
+export ALLOWED_ORIGINS=http://localhost:3000
 ./start.sh
 ```
+Puedes indicar varios orígenes separándolos con comas.
 
 ## 🧪 Cómo probar
 

--- a/tests/test_chat_endpoint.py
+++ b/tests/test_chat_endpoint.py
@@ -21,6 +21,9 @@ def client(monkeypatch):
     dummy_module.Llama = DummyLlama
     monkeypatch.setitem(sys.modules, "llama_cpp", dummy_module)
 
+    # set allowed origins for CORS tests
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://testhost")
+
     # Provide lightweight stand-ins for langchain components to avoid heavy
     # dependencies when importing the application module.
     langchain_pkg = types.ModuleType("langchain")
@@ -84,3 +87,14 @@ def test_chat_endpoint(client):
     assert resp.status_code == 200
     data = resp.json()
     assert "response" in data
+
+
+def test_cors_allows_configured_origin(client):
+    resp = client.options(
+        "/api/chat",
+        headers={
+            "Origin": "http://testhost",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert resp.headers.get("access-control-allow-origin") == "http://testhost"

--- a/vector_rag_fennec.py
+++ b/vector_rag_fennec.py
@@ -15,7 +15,17 @@ chunks = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200).spli
 vectordb = Chroma.from_documents(chunks, embedding=HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2"))
 
 app = FastAPI()
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+# determine allowed CORS origins from environment, comma separated
+default_origins = "http://localhost:3000"
+origins_str = os.getenv("ALLOWED_ORIGINS", default_origins)
+origins = [o.strip() for o in origins_str.split(",") if o.strip()]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 MODEL_PATH = os.getenv("MODEL_PATH", "./mistral-7b-instruct-v0.1.Q4_K_M.gguf")
 PORT = int(os.getenv("PORT", "8000"))


### PR DESCRIPTION
## Summary
- allow origins to be set via `ALLOWED_ORIGINS` environment variable in `vector_rag_fennec.py`
- document the new variable in the README
- test that configured origins are applied

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519be1e71c8326ad218c4826158041