### PR TITLE
Add script to serve local KB page

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ Su lógica se encuentra en `script.js` y la estructura de datos en
 la página. Mantén estos archivos en el mismo directorio para que el navegador
 pueda localizarlos sin problemas.
 
+Para evitar errores al cargar los archivos JSON, ejecuta `index.html` mediante el
+script `serve_index.sh`. Este comando inicia un servidor HTTP sencillo y abre la
+página automáticamente:
+
+```bash
+./serve_index.sh
+```
+
+Puedes cambiar el puerto estableciendo la variable `PORT` antes de ejecutarlo.
+
 ## 🛠️ Automatizar el servidor
 
 Si deseas evitar los pasos manuales cada vez que inicias el sistema,

--- a/serve_index.sh
+++ b/serve_index.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+PORT=${PORT:-8000}
+URL="http://localhost:$PORT/index.html"
+
+python3 -m http.server "$PORT" &
+SERVER_PID=$!
+
+sleep 1
+
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$URL" >/dev/null 2>&1
+elif command -v open >/dev/null 2>&1; then
+  open "$URL" >/dev/null 2>&1
+fi
+
+echo "Serving KB at $URL (Ctrl+C to stop)"
+wait $SERVER_PID


### PR DESCRIPTION
## Summary
- add `serve_index.sh` to launch a simple HTTP server for `index.html`
- document how to use the script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851aa80318c8326b75d3503e4f74d1a