### PR TITLE
Add Python server helper for index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,25 @@ Su lógica se encuentra en `script.js` y la estructura de datos en
 la página. Mantén estos archivos en el mismo directorio para que el navegador
 pueda localizarlos sin problemas.
 
-Para evitar errores al cargar los archivos JSON, ejecuta `index.html` mediante el
-script `serve_index.sh`. Este comando inicia un servidor HTTP sencillo y abre la
-página automáticamente:
+Para evitar errores al cargar los archivos JSON, ejecuta `index.html` con el
+script `serve_index.py`. Esta utilidad inicia un servidor HTTP sencillo y abre
+la página automáticamente:
 
 ```bash
-./serve_index.sh
+python3 serve_index.py
 ```
 
 Puedes cambiar el puerto estableciendo la variable `PORT` antes de ejecutarlo.
+
+Si utilizas macOS y prefieres contar con una aplicación `.app`, puedes generar
+una con `pyinstaller`:
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile --windowed serve_index.py
+```
+
+El paquete resultante se ubicará en `dist/` y podrás lanzarlo con doble clic.
 
 ## 🛠️ Automatizar el servidor
 

--- a/serve_index.py
+++ b/serve_index.py
@@ -1,0 +1,23 @@
+import http.server
+import os
+import socketserver
+import threading
+import webbrowser
+
+
+def serve_index() -> None:
+    """Serve index.html on localhost and open it in the default browser."""
+    port = int(os.environ.get("PORT", "8000"))
+    url = f"http://localhost:{port}/index.html"
+    handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", port), handler) as httpd:
+        threading.Timer(1.0, lambda: webbrowser.open(url)).start()
+        print(f"Serving KB at {url} (Ctrl+C to stop)")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            pass
+
+
+if __name__ == "__main__":
+    serve_index()


### PR DESCRIPTION
## Summary
- add `serve_index.py` to serve `index.html`
- document converting the helper into a `.app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b07c421483269363f2b8b2a64a65