### PR TITLE
Add macOS app bundle for KB viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,8 @@ python3 serve_index.py
 
 Puedes cambiar el puerto estableciendo la variable `PORT` antes de ejecutarlo.
 
-Si utilizas macOS y prefieres contar con una aplicación `.app`, puedes generar
-una con `pyinstaller`:
-
-```bash
-pip install pyinstaller
-pyinstaller --onefile --windowed serve_index.py
-```
-
-El paquete resultante se ubicará en `dist/` y podrás lanzarlo con doble clic.
+En macOS se incluye el paquete `ServeIndex.app` para abrir el visor con doble
+clic. Arrástralo a la ubicación que prefieras y ejecútalo.
 
 ## 🛠️ Automatizar el servidor
 

--- a/ServeIndex.app/Contents/Info.plist
+++ b/ServeIndex.app/Contents/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>ServeIndex</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.serveindex</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>serve_index</string>
+</dict>
+</plist>

--- a/ServeIndex.app/Contents/MacOS/serve_index
+++ b/ServeIndex.app/Contents/MacOS/serve_index
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Start the local KB server and open the page on macOS.
+DIR="$(cd "$(dirname "$0")"/../../ && pwd)"
+cd "$DIR"
+exec ./serve_index.sh


### PR DESCRIPTION
## Summary
- include ServeIndex.app for easy launching on macOS
- update README to mention ServeIndex.app

## Testing
- `pip install fastapi==0.68.0 starlette==0.14.2 pydantic==1.10.2 uvicorn==0.15.0 httpx==0.23.0`
- `pytest -q` *(fails: ForwardRef._evaluate missing keyword arg)*

------
https://chatgpt.com/codex/tasks/task_e_6851b406b6c88326b4066ac82521ed4e