### PR TITLE
Fix path for ServeIndex.app

### DIFF
--- a/ServeIndex.app/Contents/MacOS/serve_index
+++ b/ServeIndex.app/Contents/MacOS/serve_index
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Start the local KB server and open the page on macOS.
-DIR="$(cd "$(dirname "$0")"/../../ && pwd)"
+DIR="$(cd "$(dirname "$0")"/../../../ && pwd)"
 cd "$DIR"
 exec ./serve_index.sh


### PR DESCRIPTION
## Summary
- correct the relative path in `ServeIndex.app` launcher so macOS can find `serve_index.sh`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851b6dc40b88326a60f9808b3f4b014